### PR TITLE
feat: add celery task system and worker config

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI, HTTPException
+from celery.result import AsyncResult
+
+from backend.tasks import proceso_descarga, celery_app
+
+app = FastAPI()
+
+@app.post("/descargas")
+def iniciar_descarga(pasos: int = 10, pausa: float = 1.0):
+    """Inicia la descarga asíncrona y devuelve el ID de la tarea."""
+    task = proceso_descarga.delay(pasos, pausa)
+    return {"id": task.id}
+
+@app.get("/tareas/{task_id}")
+def obtener_estado(task_id: str):
+    """Devuelve el estado y porcentaje de avance de una tarea."""
+    resultado = AsyncResult(task_id, app=celery_app)
+    if resultado.state == "PENDING":
+        return {"state": resultado.state, "progress": 0}
+    if resultado.state == "PROGRESS":
+        info = resultado.info or {}
+        total = info.get("total", 1)
+        current = info.get("current", 0)
+        porcentaje = int(current / total * 100)
+        return {"state": resultado.state, "progress": porcentaje}
+    if resultado.state == "SUCCESS":
+        return {"state": resultado.state, "progress": 100, "result": resultado.result}
+    if resultado.state == "FAILURE":
+        raise HTTPException(status_code=500, detail=str(resultado.info))
+    return {"state": resultado.state}

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1,0 +1,28 @@
+import os
+import time
+from celery import Celery
+
+# Celery app configured to use Redis by default
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://redis:6379/0")
+CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", CELERY_BROKER_URL)
+
+celery_app = Celery(
+    "backend.tasks",
+    broker=CELERY_BROKER_URL,
+    backend=CELERY_RESULT_BACKEND,
+)
+
+@celery_app.task(bind=True)
+def proceso_descarga(self, pasos: int = 10, pausa: float = 1.0):
+    """Simula un proceso de descarga y reporta progreso.
+
+    Args:
+        pasos: Número de iteraciones a ejecutar.
+        pausa: Segundos a esperar entre pasos.
+    Returns:
+        Información final de la tarea.
+    """
+    for i in range(pasos):
+        time.sleep(pausa)
+        self.update_state(state="PROGRESS", meta={"current": i + 1, "total": pasos})
+    return {"current": pasos, "total": pasos, "status": "Completado"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.9"
+services:
+  api:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+    command: sh -c "pip install -r requirements.txt && uvicorn backend.api:app --host 0.0.0.0 --port 8000"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+  worker:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+    command: sh -c "pip install -r requirements.txt && celery -A backend.tasks.celery_app worker --loglevel=info"
+    depends_on:
+      - redis
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+celery
+redis
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add Celery task for `proceso_descarga` with Redis backend
- expose API endpoints to start downloads and query task state
- provide docker-compose setup for API, worker, and Redis

## Testing
- `python -m py_compile backend/tasks.py backend/api.py`


------
https://chatgpt.com/codex/tasks/task_e_68963d9c3c248329abc73b958358fb59