### PR TITLE
Configurar despliegue automático en Render

### DIFF
--- a/DEPLOY_ON_RENDER.md
+++ b/DEPLOY_ON_RENDER.md
@@ -1,0 +1,15 @@
+# Guía para desplegar en Render
+
+Sigue estos pasos para ejecutar la aplicación automáticamente en [Render](https://render.com):
+
+1. **Haz un fork o sube este repositorio a tu cuenta de Git.**
+2. Inicia sesión en Render y haz clic en **New ➝ Blueprint**.
+3. Proporciona la URL del repositorio. Render detectará el archivo `render.yaml` y creará los servicios automáticamente:
+   - API FastAPI.
+   - Worker de Celery.
+   - Base de datos Redis.
+   - Sitio estático con el frontend compilado.
+4. Haz clic en **Apply**. Se iniciará la construcción y despliegue de cada servicio.
+5. Cuando finalice el despliegue, tendrás disponible la URL pública del frontend y de la API.
+
+No es necesario configurar comandos manuales; todo está definido en `render.yaml`.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,43 @@
+services:
+  - type: web
+    name: backend
+    runtime: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn backend.api:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: CELERY_BROKER_URL
+        fromService:
+          type: redis
+          name: redis
+          property: connectionString
+      - key: CELERY_RESULT_BACKEND
+        fromService:
+          type: redis
+          name: redis
+          property: connectionString
+  - type: worker
+    name: worker
+    runtime: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: celery -A backend.tasks.celery_app worker --loglevel=info
+    envVars:
+      - key: CELERY_BROKER_URL
+        fromService:
+          type: redis
+          name: redis
+          property: connectionString
+      - key: CELERY_RESULT_BACKEND
+        fromService:
+          type: redis
+          name: redis
+          property: connectionString
+  - type: static
+    name: frontend
+    rootDir: frontend
+    buildCommand: npm install && npm run build
+    staticPublishPath: dist
+  - type: redis
+    name: redis
+    ipAllowList: []


### PR DESCRIPTION
## Resumen
- Añadido `render.yaml` con los servicios de backend, worker de Celery, frontend estático y Redis.
- Creada guía `DEPLOY_ON_RENDER.md` con pasos para desplegar el proyecto usando Render Blueprint.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68966a78a4908329892820fdb4520216